### PR TITLE
Add volume slider, add scene support, add support for renamed inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Quickly switch input using the information (i) button in the Control Centre remo
 ## Configuration
 Add a new platform to your homebridge `config.json`.
 
-Specific "favourite" inputs can be added manually or all available inputs reported by the AVR will be set.
+You can filter the available inputs that are presented in HomeKit.  The filtering is done on the "id" field, and the "id" must exactly match the name of the input on the receiver.
+**NOTE** The receiver may rename inputs, e.g. HDMI1 may become AppleTV.  Use the **NON-RENAMED** input name as the "id".
 
 Example configuration:
 
@@ -56,6 +57,16 @@ Example configuration:
             "id": "HDMI5",
             "name": "PlayStation 4"
           }
+        ],
+        "scenes": [
+           {
+              "name": "Watch AppleTV",
+              "index": 1
+           }
+           {
+              "name": "Play PS4",
+              "index": 2
+           }
         ]
       }
     ]

--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ YamahaAVRPlatform.prototype = {
          var sanitizedInputs = [];
          // If no inputs defined in config - set available inputs as returned from receiver
          this.YAMAHA.getAvailableInputsWithNames().then((availableInputs) => {
-            //this.log("Got input:", availableInputs);
             var i = 0;
             for (var key in availableInputs[0]) {
                // check if the property/key is defined in the object itself, not in parent
@@ -64,10 +63,8 @@ YamahaAVRPlatform.prototype = {
                   i++;
                }
             }
-            //this.log(sanitizedInputs);
             // Create the Yamaha AVR Accessory
             if (this.config.inputs) {
-               this.log("inputs true");
             var filteredInputs = []
             this.config.inputs.forEach((input, i) =>
             {
@@ -90,7 +87,6 @@ YamahaAVRPlatform.prototype = {
                ),
             ]);
             } else {
-               this.log("inputs false", sanitizedInputs);
                callback([
                   new YamahaAVRAccessory(
                   this.log,
@@ -145,7 +141,7 @@ YamahaAVRAccessory.prototype = {
   sceneServices() {
    this.scenes.forEach((scene, i) =>
    {
-      this.log("scene: ",scene);
+      this.log("Adding scene: ",scene);
       const sceneService = new Service.Switch(scene.name, `sceneService ${scene.index}`);
       sceneService
          .setCharacteristic(Characteristic.Name, scene.name)
@@ -308,7 +304,7 @@ YamahaAVRAccessory.prototype = {
    }
    else {
       var volume = Math.round((value/2.5-50)*10);
-      volume = volume - (volume %5);
+      volume = volume - (volume % 5);
       this.log("setting volume to ", volume);
       this.YAMAHA.setVolumeTo(volume);
    }

--- a/index.js
+++ b/index.js
@@ -267,6 +267,10 @@ YamahaAVRAccessory.prototype = {
             return null;
           });
         });
+      } else {
+         this.availableSceneServices.forEach((service) => {
+            service.getCharacteristic(Characteristic.On).updateValue(false);
+         });
       }
       return null;
     }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,43 @@
 {
-  "license": "UNLICENSED",
-  "version": "1.0.0",
-  "name": "homebridge-yamaha-avr",
-  "description": "homebridge-plugin - Add Yamaha AVR as TV with input control",
+  "_from": "homebridge-yamaha-avr",
+  "_id": "homebridge-yamaha-avr@1.0.0",
+  "_inBundle": false,
+  "_integrity": "sha512-Dnq64k0VGewswHrEAZP5rYfutqrrmII8NZ/R1vXuO9GdB4lqPxmLDPm1O2LuxIdype/QJD2+cNh8ZYjcXgYXEA==",
+  "_location": "/homebridge-yamaha-avr",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "homebridge-yamaha-avr",
+    "name": "homebridge-yamaha-avr",
+    "escapedName": "homebridge-yamaha-avr",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER"
+  ],
+  "_resolved": "https://registry.npmjs.org/homebridge-yamaha-avr/-/homebridge-yamaha-avr-1.0.0.tgz",
+  "_shasum": "b402b1b30695a4c04401c46f95164ecab468ea25",
+  "_spec": "homebridge-yamaha-avr",
+  "_where": "/Users/Ian/.homebridge",
+  "author": {
+    "name": "ACDR",
+    "email": "github@acdr.co",
+    "url": "https://github.com/ACDR"
+  },
+  "bugs": {
+    "url": "https://github.com/ACDR/homebridge-yamaha-avr/issues"
+  },
+  "bundleDependencies": false,
   "dependencies": {
     "ip": "^=1.1.5",
     "node-fetch": "^2.3.0",
     "yamaha-nodejs": ">=0.9.0"
   },
+  "deprecated": false,
+  "description": "homebridge-plugin - Add Yamaha AVR as TV with input control",
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^4.19.1",
@@ -20,27 +50,22 @@
     "homebridge": ">=0.2.5",
     "node": ">=0.12.0"
   },
-  "author": {
-    "name": "ACDR",
-    "email": "github@acdr.co",
-    "url": "https://github.com/ACDR"
-  },
   "homepage": "https://github.com/ACDR/homebridge-yamaha-avr#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ACDR/homebridge-yamaha-avr.git"
-  },
-  "bugs": {
-    "url": "https://github.com/ACDR/homebridge-yamaha-avr/issues"
-  },
   "keywords": [
     "homebridge-plugin",
     "YamahaAVR",
     "Yamaha"
   ],
+  "license": "UNLICENSED",
   "main": "index.js",
+  "name": "homebridge-yamaha-avr",
   "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ACDR/homebridge-yamaha-avr.git"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  },
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,43 +1,13 @@
 {
-  "_from": "homebridge-yamaha-avr",
-  "_id": "homebridge-yamaha-avr@1.0.0",
-  "_inBundle": false,
-  "_integrity": "sha512-Dnq64k0VGewswHrEAZP5rYfutqrrmII8NZ/R1vXuO9GdB4lqPxmLDPm1O2LuxIdype/QJD2+cNh8ZYjcXgYXEA==",
-  "_location": "/homebridge-yamaha-avr",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "tag",
-    "registry": true,
-    "raw": "homebridge-yamaha-avr",
-    "name": "homebridge-yamaha-avr",
-    "escapedName": "homebridge-yamaha-avr",
-    "rawSpec": "",
-    "saveSpec": null,
-    "fetchSpec": "latest"
-  },
-  "_requiredBy": [
-    "#USER"
-  ],
-  "_resolved": "https://registry.npmjs.org/homebridge-yamaha-avr/-/homebridge-yamaha-avr-1.0.0.tgz",
-  "_shasum": "b402b1b30695a4c04401c46f95164ecab468ea25",
-  "_spec": "homebridge-yamaha-avr",
-  "_where": "/Users/Ian/.homebridge",
-  "author": {
-    "name": "ACDR",
-    "email": "github@acdr.co",
-    "url": "https://github.com/ACDR"
-  },
-  "bugs": {
-    "url": "https://github.com/ACDR/homebridge-yamaha-avr/issues"
-  },
-  "bundleDependencies": false,
+  "license": "UNLICENSED",
+  "version": "1.0.0",
+  "name": "homebridge-yamaha-avr",
+  "description": "homebridge-plugin - Add Yamaha AVR as TV with input control",
   "dependencies": {
     "ip": "^=1.1.5",
     "node-fetch": "^2.3.0",
     "yamaha-nodejs": ">=0.9.0"
   },
-  "deprecated": false,
-  "description": "homebridge-plugin - Add Yamaha AVR as TV with input control",
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^4.19.1",
@@ -50,22 +20,27 @@
     "homebridge": ">=0.2.5",
     "node": ">=0.12.0"
   },
+  "author": {
+    "name": "ACDR",
+    "email": "github@acdr.co",
+    "url": "https://github.com/ACDR"
+  },
   "homepage": "https://github.com/ACDR/homebridge-yamaha-avr#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ACDR/homebridge-yamaha-avr.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ACDR/homebridge-yamaha-avr/issues"
+  },
   "keywords": [
     "homebridge-plugin",
     "YamahaAVR",
     "Yamaha"
   ],
-  "license": "UNLICENSED",
   "main": "index.js",
-  "name": "homebridge-yamaha-avr",
   "preferGlobal": true,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ACDR/homebridge-yamaha-avr.git"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "version": "1.0.0"
+  }
 }


### PR DESCRIPTION
Feel free to pick and choose what you want.  Scenes were the most important addition for me.  I have an open pull request against yamaha-nodejs to add the scene API to that module.

I found the input specification a bit hard to work with so I tried to update the readme and rework some of the code to handle things the yamaha does like rename inputs (again added a new API to yamaha-nodejs to support)

volume slider goes from -10 dB to -50 dB.  This works for my environment, but it may make sense to make it a config option.