### PR TITLE
Integrate Inputs like Spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ npm install -g homebridge-yamaha-avr
 ## Usage Notes
 Quickly switch input using the information (i) button in the Control Centre remote
 
+## Important Information
+If you set inputs in the config and one input is missing, that currently is set as input on your AVR, all homekit accessoires are become "not resopondig". Be sure that you set all inputs that you use.
+
 ## Configuration
 Add a new platform to your homebridge `config.json`.
 
@@ -55,6 +58,14 @@ Example configuration:
           {
             "id": "HDMI5",
             "name": "PlayStation 4"
+          },
+          {
+            "id": "Spotify",
+            "name": "Spotify"
+          },
+          {
+            "id": "AirPlay",
+            "name": "AirPlay"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g homebridge-yamaha-avr
 Quickly switch input using the information (i) button in the Control Centre remote
 
 ## Important Information
-If you set inputs in the config and one input is missing, that currently is set as input on your AVR, all homekit accessoires are become "not resopondig". Be sure that you set all inputs that you use.
+If you set inputs in the config and one input is missing, that currently is set as input on your AVR, all homekit accessories stop responding. Be sure that you set all inputs that you use.
 
 ## Configuration
 Add a new platform to your homebridge `config.json`.

--- a/simpleCommands_addition.js
+++ b/simpleCommands_addition.js
@@ -1,0 +1,28 @@
+// This whole file is only need as long the pull request of yamaha-nodejs is accepted see:
+// https://github.com/PSeitz/yamaha-nodejs/pull/34
+var Promise = require("bluebird");
+var debug = require('debug')('Yamaha-nodejs');
+var xml2js = Promise.promisifyAll(require("xml2js"));
+
+var request = Promise.promisify(require("request"));
+Promise.promisifyAll(request);
+
+
+function Yamaha() {}
+Yamaha.prototype.getAvailableFeatures = function() {
+var self = this;
+  return self.getSystemConfig().then(function(info) {
+      var features = [];
+      var featuresXML = info.YAMAHA_AV.System[0].Config[0].Feature_Existence[0];
+      debug("getAvailableFeatures",JSON.stringify(info, null, 2));
+      for (var prop in featuresXML) {
+          // Only return zones that the receiver supports
+          if (! prop.includes('one') && featuresXML[prop].includes('1')) {
+              features.push(prop);
+          }
+      }
+      return features;
+  });
+};
+
+module.exports = Yamaha;


### PR DESCRIPTION
Problem is that spotify etc. is not an input, it is a "feature" in AVR

The core problem is, that the yamaha-nodejs has no functionality to read out the features.
So I started a pull request to yamaha-nodejs.
In the meantime I added the functionality in the "simpleCommands_addition.js".